### PR TITLE
Refactoring: Use RequestHandler instead of Controller

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,8 +8,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Aheenam Test Suite">
             <directory>tests</directory>

--- a/src/Controllers/RequestHandler.php
+++ b/src/Controllers/RequestHandler.php
@@ -7,14 +7,14 @@ use Illuminate\Routing\Controller;
 use Aheenam\Mozhi\TemplateRenderer;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-class FrontendController extends Controller
+class RequestHandler extends Controller
 {
     /**
      * @param $slug
      *
      * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
      */
-    public function show($slug = 'index')
+    public function __invoke($slug = 'index')
     {
         $page = (new RouteResolver())->getPageByRoute($slug);
 

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -2,9 +2,7 @@
 
 namespace Aheenam\Mozhi;
 
-use Aheenam\Mozhi\RouteResolver;
 use Illuminate\Routing\Controller;
-use Aheenam\Mozhi\TemplateRenderer;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class RequestHandler extends Controller

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Aheenam\Mozhi\Controllers;
+namespace Aheenam\Mozhi;
 
 use Aheenam\Mozhi\RouteResolver;
 use Illuminate\Routing\Controller;

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -1,6 +1,6 @@
 <?php
 
 Route::any('{slug?}')
-    ->uses(\Aheenam\Mozhi\Controllers\RequestHandler::class)
+    ->uses(\Aheenam\Mozhi\RequestHandler::class)
     ->name('mozhi.page')
     ->where('slug', '.*');

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -1,6 +1,6 @@
 <?php
 
 Route::any('{slug?}')
-    ->uses(\Aheenam\Mozhi\Controllers\FrontendController::class.'@show')
+    ->uses(\Aheenam\Mozhi\Controllers\RequestHandler::class)
     ->name('mozhi.page')
     ->where('slug', '.*');


### PR DESCRIPTION
As the FrontendController had just one job, it was not necessary to have a full Controller for that. Now it is a single action controller.