### PR TITLE
Upgrade to Laravel 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,15 +8,15 @@
   "require": {
     "php" : "^7.1",
     "spatie/yaml-front-matter": "^2.0",
-    "Illuminate/Support": "^5.5|^5.6",
-    "Illuminate/Routing": "^5.5|^5.6",
-    "Illuminate/Http": "^5.5|^5.6",
+    "Illuminate/Support": "^5.6|^5.7",
+    "Illuminate/Routing": "^5.6|^5.7",
+    "Illuminate/Http": "^5.6|^5.7",
     "league/commonmark": "^0.16.0",
     "webuni/commonmark-table-extension": "^0.8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.3|^7.0",
-    "orchestra/testbench": "~3.5.0|~3.6.0",
+    "orchestra/testbench": "~3.6.0|~3.7.0",
     "spatie/phpunit-snapshot-assertions": "^1.1"
   },
   "autoload": {


### PR DESCRIPTION
Drops support for Laravel 5.5.

---

closes #16 